### PR TITLE
Allow toggling request completion status

### DIFF
--- a/backend/templates/backend/request/cud.html
+++ b/backend/templates/backend/request/cud.html
@@ -18,7 +18,7 @@
                     <div class="field">
                         <div class="control">
                             <label class="checkbox">
-                                {{ form.is_completed }} Mark as completed
+                                {{ form.is_completed }} Mark as completed/uncompleted
                             </label>
                         </div>
                     </div>

--- a/backend/tests.py
+++ b/backend/tests.py
@@ -249,6 +249,26 @@ class RequestCompletionTest(TestCase):
         self.assertNotContains(response, "Request 1")
         self.assertContains(response, "Request 2")
 
+    def test_toggle_is_completed(self):
+        self.client.login(username="user1", password="password1")
+        response = self.client.post(reverse("request_update", args=[self.request1.pk]), {
+            "name": self.request1.name,
+            "request_type": self.request1.request_type,
+            "is_completed": True,
+        })
+        self.assertEqual(response.status_code, 302)  # Redirect after successful update
+        self.request1.refresh_from_db()
+        self.assertTrue(self.request1.is_completed)
+
+        response = self.client.post(reverse("request_update", args=[self.request1.pk]), {
+            "name": self.request1.name,
+            "request_type": self.request1.request_type,
+            "is_completed": False,
+        })
+        self.assertEqual(response.status_code, 302)  # Redirect after successful update
+        self.request1.refresh_from_db()
+        self.assertFalse(self.request1.is_completed)
+
     def tearDown(self):
         Request.objects.all().delete()
         Community.objects.all().delete()

--- a/backend/views.py
+++ b/backend/views.py
@@ -372,6 +372,10 @@ class RequestUpdateView(RequestBaseView , generic.UpdateView):
     def get_queryset(self):
         return Request.objects.filter(owner=self.request.user)
 
+    def form_valid(self, form):
+        form.instance.is_completed = form.cleaned_data.get("is_completed", False)
+        return super().form_valid(form)
+
 
 class RequestDeleteView(generic.DeleteView):
     template_name = "backend/request/cud.html"


### PR DESCRIPTION
Update the UI and backend to allow toggling the `is_completed` field for requests.

* **UI Update**
  - Change the checkbox label in `backend/templates/backend/request/cud.html` to "Mark as completed/uncompleted".

* **Backend Update**
  - Modify `RequestUpdateView` in `backend/views.py` to allow toggling the `is_completed` field.
  - Add a test in `backend/tests.py` to verify toggling the `is_completed` field.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/musadiqpeerzada/closeknit/pull/8?shareId=6b50dc21-3865-4efc-8bcf-1bffbc356e8f).