### PR TITLE
Fix duplicate requests for users in multiple communities

### DIFF
--- a/backend/services.py
+++ b/backend/services.py
@@ -40,7 +40,7 @@ def get_requests_for_user(user: User) -> QuerySet[Request]:
     requests_shared_to_communities_the_user_belongs_to = Request.objects.filter(
         shared_with__in=communities_the_user_belongs_to
     )
-    return requests_shared_to_communities_the_user_belongs_to.exclude(owner=user)
+    return requests_shared_to_communities_the_user_belongs_to.exclude(owner=user).distinct()
 
 def get_subscriptions_available_for_share(user: User) -> QuerySet[Subscription]:
     communities_the_user_belongs_to = Community.objects.filter(members=user)


### PR DESCRIPTION
Update `get_requests_for_user` function to remove duplicate requests for users in multiple communities.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/musadiqpeerzada/closeknit/pull/9?shareId=a2e0bcf5-6800-47d6-8f9b-f7cd03d5d5dd).